### PR TITLE
Component name fix

### DIFF
--- a/Core/Objects/Components/ComponentArrays/AngularSpeedArray.hpp
+++ b/Core/Objects/Components/ComponentArrays/AngularSpeedArray.hpp
@@ -31,6 +31,7 @@ namespace Barrage
 
   typedef ComponentArrayT<AngularSpeed> AngularSpeedArray;
 
+  template <>
   inline std::string AngularSpeedArray::GetClassName() { return "AngularSpeedArray"; }
 }
 

--- a/Core/Objects/Components/ComponentArrays/DestructibleArray.hpp
+++ b/Core/Objects/Components/ComponentArrays/DestructibleArray.hpp
@@ -30,6 +30,7 @@ namespace Barrage
 
   typedef ComponentArrayT<Destructible> DestructibleArray;
 
+  template <>
   inline std::string DestructibleArray::GetClassName() { return "DestructibleArray"; }
 }
 

--- a/Core/Objects/Components/ComponentArrays/LifetimeArray.hpp
+++ b/Core/Objects/Components/ComponentArrays/LifetimeArray.hpp
@@ -30,6 +30,7 @@ namespace Barrage
 
   typedef ComponentArrayT<Lifetime> LifetimeArray;
 
+  template <>
   inline std::string LifetimeArray::GetClassName() { return "LifetimeArray"; }
 }
 

--- a/Core/Objects/Components/ComponentArrays/PositionArray.hpp
+++ b/Core/Objects/Components/ComponentArrays/PositionArray.hpp
@@ -30,6 +30,7 @@ namespace Barrage
 
   typedef ComponentArrayT<Position> PositionArray;
 
+  template <>
   inline std::string PositionArray::GetClassName() { return "PositionArray"; }
 }
 

--- a/Core/Objects/Components/ComponentArrays/RotationArray.hpp
+++ b/Core/Objects/Components/ComponentArrays/RotationArray.hpp
@@ -31,6 +31,7 @@ namespace Barrage
 
   typedef ComponentArrayT<Rotation> RotationArray;
 
+  template <>
   inline std::string RotationArray::GetClassName() { return "RotationArray"; }
 }
 

--- a/Core/Objects/Components/ComponentArrays/ScaleArray.hpp
+++ b/Core/Objects/Components/ComponentArrays/ScaleArray.hpp
@@ -30,6 +30,7 @@ namespace Barrage
 
   typedef ComponentArrayT<Scale> ScaleArray;
 
+  template <>
   inline std::string ScaleArray::GetClassName() { return "ScaleArray"; }
 }
 

--- a/Core/Objects/Components/ComponentArrays/VelocityArray.hpp
+++ b/Core/Objects/Components/ComponentArrays/VelocityArray.hpp
@@ -31,6 +31,7 @@ namespace Barrage
 
   typedef ComponentArrayT<Velocity> VelocityArray;
 
+  template <>
   inline std::string VelocityArray::GetClassName() { return "VelocityArray"; }
 }
 

--- a/Core/Objects/ObjectManager.cpp
+++ b/Core/Objects/ObjectManager.cpp
@@ -31,7 +31,7 @@ namespace Barrage
     RegisterEngineSpawnFuncs();
     SetDefaultSystemUpdateOrder();
 
-    CreationSystem* creation_system = dynamic_cast<CreationSystem*>(systemManager_.systems_.at("Creation System"));
+    CreationSystem* creation_system = dynamic_cast<CreationSystem*>(systemManager_.systems_.at("CreationSystem"));
 
     creation_system->SetArchetypeManager(archetypeManager_);
     creation_system->SetSpawnFuncManager(spawnFuncManager_);
@@ -58,7 +58,7 @@ namespace Barrage
     Pool* pool = poolManager_.GetPool(poolName);
     ObjectArchetype* archetype = archetypeManager_.GetObjectArchetype(archetypeName);
 
-    CreationSystem* creation_system = dynamic_cast<CreationSystem*>(systemManager_.systems_["Creation System"]);
+    CreationSystem* creation_system = dynamic_cast<CreationSystem*>(systemManager_.systems_["CreationSystem"]);
 
     if (pool && archetype && creation_system)
     {
@@ -168,7 +168,7 @@ namespace Barrage
 
   void ObjectManager::Draw()
   {
-    DrawSystem* draw_system = dynamic_cast<DrawSystem*>(systemManager_.systems_["Draw System"]);
+    DrawSystem* draw_system = dynamic_cast<DrawSystem*>(systemManager_.systems_["DrawSystem"]);
 
     if (draw_system)
     {
@@ -178,16 +178,16 @@ namespace Barrage
 
   void ObjectManager::RegisterEngineComponents()
   {
-    RegisterComponent<AngularSpeedArray>("Angular Speed Array");
-    RegisterComponent<DestructibleArray>("Destructible Array");
-    RegisterComponent<LifetimeArray>("Lifetime Array");
-    RegisterComponent<PositionArray>("Position Array");
-    RegisterComponent<RotationArray>("Rotation Array");
-    RegisterComponent<ScaleArray>("Scale Array");
-    RegisterComponent<VelocityArray>("Velocity Array");
+    RegisterComponent<AngularSpeedArray>("AngularSpeedArray");
+    RegisterComponent<DestructibleArray>("DestructibleArray");
+    RegisterComponent<LifetimeArray>("LifetimeArray");
+    RegisterComponent<PositionArray>("PositionArray");
+    RegisterComponent<RotationArray>("RotationArray");
+    RegisterComponent<ScaleArray>("ScaleArray");
+    RegisterComponent<VelocityArray>("VelocityArray");
 
-    RegisterComponent<BoundaryBox>("Boundary Box");
-    RegisterComponent<CircleCollider>("Circle Collider");
+    RegisterComponent<BoundaryBox>("BoundaryBox");
+    RegisterComponent<CircleCollider>("CircleCollider");
     RegisterComponent<Spawner>("Spawner");
     RegisterComponent<Sprite>("Sprite");
     RegisterComponent<RNG>("RNG");
@@ -195,28 +195,28 @@ namespace Barrage
 
   void ObjectManager::RegisterEngineSystems()
   {
-    RegisterSystem<CreationSystem>("Creation System");
-    RegisterSystem<DestructionSystem>("Destruction System");
-    RegisterSystem<DrawSystem>("Draw System");
-    RegisterSystem<MovementSystem>("Movement System");
-    RegisterSystem<CollisionSystem>("Collision System");
+    RegisterSystem<CreationSystem>("CreationSystem");
+    RegisterSystem<DestructionSystem>("DestructionSystem");
+    RegisterSystem<DrawSystem>("DrawSystem");
+    RegisterSystem<MovementSystem>("MovementSystem");
+    RegisterSystem<CollisionSystem>("CollisionSystem");
   }
 
   void ObjectManager::RegisterEngineSpawnFuncs()
   {
-    RegisterSpawnFunc("Random Direction", Spawn::RandomDirection);
-    RegisterSpawnFunc("Match Position", Spawn::MatchPosition);
+    RegisterSpawnFunc("RandomDirection", Spawn::RandomDirection);
+    RegisterSpawnFunc("MatchPosition", Spawn::MatchPosition);
   }
 
   void ObjectManager::SetDefaultSystemUpdateOrder()
   {
     std::vector<std::string> update_order;
 
-    update_order.push_back("Creation System");
-    update_order.push_back("Destruction System");
-    update_order.push_back("Movement System");
-    update_order.push_back("Creation System");
-    update_order.push_back("Collision System");
+    update_order.push_back("CreationSystem");
+    update_order.push_back("DestructionSystem");
+    update_order.push_back("MovementSystem");
+    update_order.push_back("CreationSystem");
+    update_order.push_back("CollisionSystem");
 
     SetSystemUpdateOrder(update_order);
   }

--- a/Core/Objects/SpawnFuncs/Direction/DirectionFuncs.cpp
+++ b/Core/Objects/SpawnFuncs/Direction/DirectionFuncs.cpp
@@ -23,7 +23,7 @@ namespace Barrage
       UNREFERENCED(sourceIndices);
       
       Random& rng = initPool.GetSharedComponent<RNG>("RNG")->rng_;
-      VelocityArray& dest_velocities = *destPool.GetComponentArray<VelocityArray>("Velocity Array");
+      VelocityArray& dest_velocities = *destPool.GetComponentArray<VelocityArray>("VelocityArray");
 
       for (unsigned i = 0; i < numNewObjects; ++i)
       {

--- a/Core/Objects/SpawnFuncs/Position/PositionFuncs.cpp
+++ b/Core/Objects/SpawnFuncs/Position/PositionFuncs.cpp
@@ -19,8 +19,8 @@ namespace Barrage
   {
     void MatchPosition(Pool& initPool, Pool& destPool, unsigned firstObjIndex, unsigned numNewObjects, const std::vector<unsigned>& sourceIndices)
     {
-      PositionArray& source_positions = *initPool.GetComponentArray<PositionArray>("Position Array");
-      PositionArray& dest_positions = *destPool.GetComponentArray<PositionArray>("Position Array");
+      PositionArray& source_positions = *initPool.GetComponentArray<PositionArray>("PositionArray");
+      PositionArray& dest_positions = *destPool.GetComponentArray<PositionArray>("PositionArray");
 
       for (unsigned i = 0; i < numNewObjects; ++i)
       {

--- a/Core/Objects/Systems/Collision/CollisionSystem.cpp
+++ b/Core/Objects/Systems/Collision/CollisionSystem.cpp
@@ -23,22 +23,22 @@ namespace Barrage
     System()
   {
     PoolType circle_bullet_type;
-    circle_bullet_type.AddComponentName("Circle Collider");
-    circle_bullet_type.AddComponentName("Position Array");
-    circle_bullet_type.AddComponentName("Destructible Array");
+    circle_bullet_type.AddComponentName("CircleCollider");
+    circle_bullet_type.AddComponentName("PositionArray");
+    circle_bullet_type.AddComponentName("DestructibleArray");
     circle_bullet_type.AddTag("Bullet");
     poolTypes_[CIRCLE_BULLET_POOLS] = circle_bullet_type;
 
     PoolType bounded_bullet_type;
-    bounded_bullet_type.AddComponentName("Position Array");
-    bounded_bullet_type.AddComponentName("Boundary Box");
-    bounded_bullet_type.AddComponentName("Destructible Array");
+    bounded_bullet_type.AddComponentName("PositionArray");
+    bounded_bullet_type.AddComponentName("BoundaryBox");
+    bounded_bullet_type.AddComponentName("DestructibleArray");
     bounded_bullet_type.AddTag("Bullet");
     poolTypes_[BOUNDED_BULLET_POOLS] = bounded_bullet_type;
 
     PoolType circle_player_type;
-    circle_player_type.AddComponentName("Circle Collider");
-    circle_player_type.AddComponentName("Position Array");
+    circle_player_type.AddComponentName("CircleCollider");
+    circle_player_type.AddComponentName("PositionArray");
     circle_player_type.AddTag("Player");
     poolTypes_[CIRCLE_PLAYER_POOLS] = circle_player_type;
   }
@@ -52,10 +52,10 @@ namespace Barrage
 
   void CollisionSystem::UpdateBoundedBullets(Pool* pool)
   {
-    PositionArray& position_array = *pool->GetComponentArray<PositionArray>("Position Array");
-    DestructibleArray& destructible_array = *pool->GetComponentArray<DestructibleArray>("Destructible Array");
+    PositionArray& position_array = *pool->GetComponentArray<PositionArray>("PositionArray");
+    DestructibleArray& destructible_array = *pool->GetComponentArray<DestructibleArray>("DestructibleArray");
 
-    BoundaryBox& boundary_box = *pool->GetSharedComponent<BoundaryBox>("Boundary Box");
+    BoundaryBox& boundary_box = *pool->GetSharedComponent<BoundaryBox>("BoundaryBox");
 
     unsigned num_bullets = pool->size_;
 
@@ -72,13 +72,13 @@ namespace Barrage
 
   void CollisionSystem::UpdatePlayerBulletCollisions(Pool* player_pool, Pool* bullet_pool)
   {
-    CircleCollider& player_collider = *player_pool->GetSharedComponent<CircleCollider>("Circle Collider");
-    CircleCollider& bullet_collider = *bullet_pool->GetSharedComponent<CircleCollider>("Circle Collider");
+    CircleCollider& player_collider = *player_pool->GetSharedComponent<CircleCollider>("CircleCollider");
+    CircleCollider& bullet_collider = *bullet_pool->GetSharedComponent<CircleCollider>("CircleCollider");
 
-    PositionArray& player_positions = *player_pool->GetComponentArray<PositionArray>("Position Array");
-    PositionArray& bullet_positions = *bullet_pool->GetComponentArray<PositionArray>("Position Array");
+    PositionArray& player_positions = *player_pool->GetComponentArray<PositionArray>("PositionArray");
+    PositionArray& bullet_positions = *bullet_pool->GetComponentArray<PositionArray>("PositionArray");
 
-    DestructibleArray& bullet_destructibles = *bullet_pool->GetComponentArray<DestructibleArray>("Destructible Array");
+    DestructibleArray& bullet_destructibles = *bullet_pool->GetComponentArray<DestructibleArray>("DestructibleArray");
 
     float collision_radius = player_collider.radius_ + bullet_collider.radius_;
 

--- a/Core/Objects/Systems/Destruction/DestructionSystem.cpp
+++ b/Core/Objects/Systems/Destruction/DestructionSystem.cpp
@@ -21,7 +21,7 @@ namespace Barrage
     System()
   {
     PoolType destructible_type;
-    destructible_type.AddComponentName("Destructible Array");
+    destructible_type.AddComponentName("DestructibleArray");
     poolTypes_[BASIC_DESTRUCTIBLE_POOLS] = destructible_type;
   }
   
@@ -40,7 +40,7 @@ namespace Barrage
 
   void DestructionSystem::PerObjectDestructionAlgorithm(Pool* pool)
   {
-    DestructibleArray& destructible_array = *pool->GetComponentArray<DestructibleArray>("Destructible Array");
+    DestructibleArray& destructible_array = *pool->GetComponentArray<DestructibleArray>("DestructibleArray");
 
     /*
      *  Objectives:
@@ -87,7 +87,7 @@ namespace Barrage
 
   void DestructionSystem::PerComponentDestructionAlgorithm(Pool* pool)
   {
-    DestructibleArray& destructible_array = *pool->GetComponentArray<DestructibleArray>("Destructible Array");
+    DestructibleArray& destructible_array = *pool->GetComponentArray<DestructibleArray>("DestructibleArray");
 
     /*
      *  Objectives:
@@ -117,7 +117,7 @@ namespace Barrage
     for (auto it = pool->componentArrays_.begin(); it != pool->componentArrays_.end(); ++it)
     {
       // we'll operate on the destructible array last; after the loop finishes
-      if (it->first == "Destructible Array")
+      if (it->first == "DestructibleArray")
         continue;
       
       unsigned alive_end_index = initial_alive_end_index;

--- a/Core/Objects/Systems/Draw/DrawSystem.cpp
+++ b/Core/Objects/Systems/Draw/DrawSystem.cpp
@@ -23,9 +23,9 @@ namespace Barrage
     System()
   {
     PoolType basic_sprite_type;
-    basic_sprite_type.AddComponentName("Position Array");
-    basic_sprite_type.AddComponentName("Scale Array");
-    basic_sprite_type.AddComponentName("Rotation Array");
+    basic_sprite_type.AddComponentName("PositionArray");
+    basic_sprite_type.AddComponentName("ScaleArray");
+    basic_sprite_type.AddComponentName("RotationArray");
     basic_sprite_type.AddComponentName("Sprite");
     poolTypes_[BASIC_2D_SPRITE_POOLS] = basic_sprite_type;
   }
@@ -46,9 +46,9 @@ namespace Barrage
     {
       Pool* pool = it->second;
 
-      PositionArray& position_array = *pool->GetComponentArray<PositionArray>("Position Array");
-      ScaleArray& scale_array = *pool->GetComponentArray<ScaleArray>("Scale Array");
-      RotationArray& rotation_array = *pool->GetComponentArray<RotationArray>("Rotation Array");
+      PositionArray& position_array = *pool->GetComponentArray<PositionArray>("PositionArray");
+      ScaleArray& scale_array = *pool->GetComponentArray<ScaleArray>("ScaleArray");
+      RotationArray& rotation_array = *pool->GetComponentArray<RotationArray>("RotationArray");
 
       glm::vec2* positions = reinterpret_cast<glm::vec2*>(position_array.data_);
       glm::vec2* scales = reinterpret_cast<glm::vec2*>(scale_array.data_);

--- a/Core/Objects/Systems/Movement/MovementSystem.cpp
+++ b/Core/Objects/Systems/Movement/MovementSystem.cpp
@@ -25,23 +25,23 @@ namespace Barrage
     System()
   {
     PoolType basic_movement_type;
-    basic_movement_type.AddComponentName("Position Array");
-    basic_movement_type.AddComponentName("Velocity Array");
+    basic_movement_type.AddComponentName("PositionArray");
+    basic_movement_type.AddComponentName("VelocityArray");
     poolTypes_[BASIC_MOVEMENT_POOLS] = basic_movement_type;
 
     PoolType basic_rotation_type;
-    basic_rotation_type.AddComponentName("Rotation Array");
-    basic_rotation_type.AddComponentName("Angular Speed Array");
+    basic_rotation_type.AddComponentName("RotationArray");
+    basic_rotation_type.AddComponentName("AngularSpeedArray");
     poolTypes_[BASIC_ROTATION_POOLS] = basic_rotation_type;
 
     PoolType player_type;
-    player_type.AddComponentName("Position Array");
+    player_type.AddComponentName("PositionArray");
     player_type.AddTag("Player");
     poolTypes_[PLAYER_POOLS] = player_type;
 
     PoolType bounded_player_type;
-    bounded_player_type.AddComponentName("Position Array");
-    bounded_player_type.AddComponentName("Boundary Box");
+    bounded_player_type.AddComponentName("PositionArray");
+    bounded_player_type.AddComponentName("BoundaryBox");
     bounded_player_type.AddTag("Player");
     poolTypes_[BOUNDED_PLAYER_POOLS] = bounded_player_type;
   }
@@ -87,7 +87,7 @@ namespace Barrage
       player_velocity.vy_ = player_velocity.vy_ / 1.4142f;
     }
 
-    PositionArray& position_array = *pool->GetComponentArray<PositionArray>("Position Array");
+    PositionArray& position_array = *pool->GetComponentArray<PositionArray>("PositionArray");
 
     unsigned num_objects = pool->size_;
 
@@ -100,8 +100,8 @@ namespace Barrage
 
   void MovementSystem::UpdatePlayerBounds(Pool* pool)
   {
-    PositionArray& position_array = *pool->GetComponentArray<PositionArray>("Position Array");
-    BoundaryBox& bounds = *pool->GetSharedComponent<BoundaryBox>("Boundary Box");
+    PositionArray& position_array = *pool->GetComponentArray<PositionArray>("PositionArray");
+    BoundaryBox& bounds = *pool->GetSharedComponent<BoundaryBox>("BoundaryBox");
 
     unsigned num_objects = pool->size_;
 
@@ -123,8 +123,8 @@ namespace Barrage
 
   void MovementSystem::UpdateBasicMovement(Pool* pool)
   {
-    PositionArray& position_array = *pool->GetComponentArray<PositionArray>("Position Array");
-    VelocityArray& velocity_array = *pool->GetComponentArray<VelocityArray>("Velocity Array");
+    PositionArray& position_array = *pool->GetComponentArray<PositionArray>("PositionArray");
+    VelocityArray& velocity_array = *pool->GetComponentArray<VelocityArray>("VelocityArray");
 
     unsigned num_objects = pool->size_;
 
@@ -137,8 +137,8 @@ namespace Barrage
 
   void MovementSystem::UpdateBasicRotation(Pool* pool)
   {
-    RotationArray& rotation_array = *pool->GetComponentArray<RotationArray>("Rotation Array");
-    AngularSpeedArray& angular_speed_array = *pool->GetComponentArray<AngularSpeedArray>("Angular Speed Array");
+    RotationArray& rotation_array = *pool->GetComponentArray<RotationArray>("RotationArray");
+    AngularSpeedArray& angular_speed_array = *pool->GetComponentArray<AngularSpeedArray>("AngularSpeedArray");
 
     unsigned num_objects = pool->size_;
 

--- a/Samples/DemoGame/Source/Archetypes/DemoArchetypes.cpp
+++ b/Samples/DemoGame/Source/Archetypes/DemoArchetypes.cpp
@@ -29,7 +29,7 @@ namespace Demo
 
     CircleCollider* circle_collider = new CircleCollider;
     circle_collider->radius_ = 16.0f;
-    pool_archetype->sharedComponents_["Circle Collider"] = circle_collider;
+    pool_archetype->sharedComponents_["CircleCollider"] = circle_collider;
 
     Sprite* sprite = new Sprite;
     sprite->layer_ = 0;
@@ -41,12 +41,12 @@ namespace Demo
     boundary_box->xMax_ = 1248.0f;
     boundary_box->yMin_ = 32.0f;
     boundary_box->yMax_ = 688.0f;
-    pool_archetype->sharedComponents_["Boundary Box"] = boundary_box;
+    pool_archetype->sharedComponents_["BoundaryBox"] = boundary_box;
 
-    pool_archetype->componentArrayNames_.push_back("Position Array");
-    pool_archetype->componentArrayNames_.push_back("Rotation Array");
-    pool_archetype->componentArrayNames_.push_back("Scale Array");
-    pool_archetype->componentArrayNames_.push_back("Velocity Array");
+    pool_archetype->componentArrayNames_.push_back("PositionArray");
+    pool_archetype->componentArrayNames_.push_back("RotationArray");
+    pool_archetype->componentArrayNames_.push_back("ScaleArray");
+    pool_archetype->componentArrayNames_.push_back("VelocityArray");
 
     Engine::Instance->Objects().AddPoolArchetype("Player Pool Archetype", pool_archetype);
 
@@ -56,21 +56,21 @@ namespace Demo
     position_array->Allocate(1);
     position_array->data_->x_ = 640.0f;
     position_array->data_->y_ = 120.0f;
-    object_archetype->components_["Position Array"] = position_array;
+    object_archetype->components_["PositionArray"] = position_array;
 
     RotationArray* rotation_array = new RotationArray;
     rotation_array->Allocate(1);
-    object_archetype->components_["Rotation Array"] = rotation_array;
+    object_archetype->components_["RotationArray"] = rotation_array;
 
     ScaleArray* scale_array = new ScaleArray;
     scale_array->Allocate(1);
     scale_array->data_->w_ = 64.0f;
     scale_array->data_->h_ = 64.0f;
-    object_archetype->components_["Scale Array"] = scale_array;
+    object_archetype->components_["ScaleArray"] = scale_array;
 
     VelocityArray* velocity_array = new VelocityArray;
     velocity_array->Allocate(1);
-    object_archetype->components_["Velocity Array"] = velocity_array;
+    object_archetype->components_["VelocityArray"] = velocity_array;
 
     Engine::Instance->Objects().AddObjectArchetype("Player Object Archetype", object_archetype);
   }
@@ -83,7 +83,7 @@ namespace Demo
 
     CircleCollider* circle_collider = new CircleCollider;
     circle_collider->radius_ = 16.0f;
-    pool_archetype->sharedComponents_["Circle Collider"] = circle_collider;
+    pool_archetype->sharedComponents_["CircleCollider"] = circle_collider;
 
     Sprite* sprite = new Sprite;
     sprite->layer_ = 1;
@@ -95,13 +95,13 @@ namespace Demo
     boundary_box->xMax_ = 1296.0f;
     boundary_box->yMin_ = -16.0f;
     boundary_box->yMax_ = 736.0f;
-    pool_archetype->sharedComponents_["Boundary Box"] = boundary_box;
+    pool_archetype->sharedComponents_["BoundaryBox"] = boundary_box;
 
-    pool_archetype->componentArrayNames_.push_back("Position Array");
-    pool_archetype->componentArrayNames_.push_back("Rotation Array");
-    pool_archetype->componentArrayNames_.push_back("Scale Array");
-    pool_archetype->componentArrayNames_.push_back("Velocity Array");
-    pool_archetype->componentArrayNames_.push_back("Destructible Array");
+    pool_archetype->componentArrayNames_.push_back("PositionArray");
+    pool_archetype->componentArrayNames_.push_back("RotationArray");
+    pool_archetype->componentArrayNames_.push_back("ScaleArray");
+    pool_archetype->componentArrayNames_.push_back("VelocityArray");
+    pool_archetype->componentArrayNames_.push_back("DestructibleArray");
 
     Engine::Instance->Objects().AddPoolArchetype("Bullet Pool Archetype", pool_archetype);
 
@@ -111,25 +111,25 @@ namespace Demo
     position_array->Allocate(1);
     position_array->data_->x_ = 640.0f;
     position_array->data_->y_ = 120.0f;
-    object_archetype->components_["Position Array"] = position_array;
+    object_archetype->components_["PositionArray"] = position_array;
 
     RotationArray* rotation_array = new RotationArray;
     rotation_array->Allocate(1);
-    object_archetype->components_["Rotation Array"] = rotation_array;
+    object_archetype->components_["RotationArray"] = rotation_array;
 
     ScaleArray* scale_array = new ScaleArray;
     scale_array->Allocate(1);
     scale_array->data_->w_ = 32.0f;
     scale_array->data_->h_ = 32.0f;
-    object_archetype->components_["Scale Array"] = scale_array;
+    object_archetype->components_["ScaleArray"] = scale_array;
 
     VelocityArray* velocity_array = new VelocityArray;
     velocity_array->Allocate(1);
-    object_archetype->components_["Velocity Array"] = velocity_array;
+    object_archetype->components_["VelocityArray"] = velocity_array;
 
     DestructibleArray* destructible_array = new DestructibleArray;
     destructible_array->Allocate(1);
-    object_archetype->components_["Destructible Array"] = destructible_array;
+    object_archetype->components_["DestructibleArray"] = destructible_array;
 
     Engine::Instance->Objects().AddObjectArchetype("Bullet Object Archetype", object_archetype);
   }
@@ -145,8 +145,8 @@ namespace Demo
     bullet_spawn_type.poolName_ = "Bullet Pool";
     bullet_spawn_type.spawnNum_ = 0;
     bullet_spawn_type.sourceIndices_.resize(10000);
-    bullet_spawn_type.spawnFuncs_.push_back("Match Position");
-    bullet_spawn_type.spawnFuncs_.push_back("Random Direction");
+    bullet_spawn_type.spawnFuncs_.push_back("MatchPosition");
+    bullet_spawn_type.spawnFuncs_.push_back("RandomDirection");
 
     Spawner* spawner = new Spawner;
     spawner->spawnTypes_.push_back(bullet_spawn_type);
@@ -155,7 +155,7 @@ namespace Demo
     RNG* rng = new RNG;
     pool_archetype->sharedComponents_["RNG"] = rng;
 
-    pool_archetype->componentArrayNames_.push_back("Position Array");
+    pool_archetype->componentArrayNames_.push_back("PositionArray");
 
     Engine::Instance->Objects().AddPoolArchetype("Spawner Pool Archetype", pool_archetype);
 
@@ -165,7 +165,7 @@ namespace Demo
     position_array->Allocate(1);
     position_array->data_->x_ = 640.0f;
     position_array->data_->y_ = 600.0f;
-    object_archetype->components_["Position Array"] = position_array;
+    object_archetype->components_["PositionArray"] = position_array;
 
     Engine::Instance->Objects().AddObjectArchetype("Spawner Object Archetype", object_archetype);
   }

--- a/Samples/DemoGame/Source/Registration.cpp
+++ b/Samples/DemoGame/Source/Registration.cpp
@@ -27,7 +27,7 @@ namespace Barrage
 
   void ObjectManager::RegisterCustomSystems()
   {
-    RegisterSystem<Demo::SpawnSystem>("Spawn System");
+    RegisterSystem<Demo::SpawnSystem>("SpawnSystem");
   }
 
   void ObjectManager::RegisterCustomSpawnFuncs()


### PR DESCRIPTION
### Overview
The registered names of Components, Systems, and SpawnFuncs now match their class names. In addition, this PR fixes a template syntax error in all the specialized "GetClassName()" functions.

### Motivation
It can now be assumed that registered names for the above classes match their class name. This should help with reflection.

### Testing
DemoGame.exe and Editor.exe have been built and run successfully.